### PR TITLE
Only assert num_rows equality for Tables

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -1,3 +1,4 @@
+from parsons.etl.table import Table
 import os
 import pytest
 
@@ -32,7 +33,8 @@ def assert_matching_tables(table1, table2, ignore_headers=False):
         data1 = table1
         data2 = table2
 
-    assert data1.num_rows == data2.num_rows 
+    if isinstance(data1, Table) and isinstance(data2, Table):
+        assert data1.num_rows == data2.num_rows
 
     for r1, r2 in zip(data1, data2):
         # Cast both rows to lists, in case they are different types of collections


### PR DESCRIPTION
Sometimes assert_matching_tables function takes 'list' types as arguments, which causes an error when trying to call .num_rows on the lists. Only check num_rows for equality if both parameters are Table type