### PR TITLE
Update setup_google_application_credentials to support dict parameter

### DIFF
--- a/parsons/google/utitities.py
+++ b/parsons/google/utitities.py
@@ -5,12 +5,13 @@ import os
 
 
 def setup_google_application_credentials(app_creds, env_var_name='GOOGLE_APPLICATION_CREDENTIALS'):
-    # Detect if the app_creds string is a path or json and if it is a
+    # Detect if app_creds is a dict, path string or json string, and if it is a
     # json string, then convert it to a temporary file. Then set the
     # environmental variable.
     credentials = check_env.check(env_var_name, app_creds)
     try:
-        json.loads(credentials)
+        if (type(credentials) is dict):
+            credentials = json.dumps(credentials)
         creds_path = files.string_to_temp_file(credentials, suffix='.json')
     except ValueError:
         creds_path = credentials


### PR DESCRIPTION
After recent code changes, the `GoogleSheets.__init__` function in `google_sheets.py` (in the `google` directory) calls the `setup_google_application_credentials` function with a `dict` type parameter. The `setup_google_application_credentials` function needs to be updated to handle this type, since it currently expects either a JSON object string or a string path to a file.

As part of this change, I removed the `json.loads(credentials)`, line because I don't believe it is doing anything. I stepped through with a debugger and saw no change to the `credentials` parameter before and after that line executed. When I added a variable to capture the return value, (e.g. `test = json.loads(credentials)`), the return value was a dict while the input `credentials` parameter remained a string. [This tutorial](https://www.w3schools.com/python/python_json.asp) seems to demonstrate that the function has a return value, but [the documentation](https://docs.python.org/3/library/json.html) seems to indicate that the input parameter is transformed. Honestly, I'm pretty confused, so I decided to trust what I saw in the debugger and remove the line. I would love any input or correction.

To test, I ran `pip install --no-deps -e git+https://github.com/MoveOnOrg/parsons.git@alex-support-dict-param#egg=parsons` in my `redash-uploader` repository, and was able to run that script successfully with these changes. If you have any suggestions on how to test code that passes in a JSON string or path string to this function, please let me know!