### PR TITLE
Update authorization library for Google Sheets to support account delegation

### DIFF
--- a/parsons/google/google_sheets.py
+++ b/parsons/google/google_sheets.py
@@ -6,7 +6,7 @@ from parsons.etl.table import Table
 from parsons.google.utitities import setup_google_application_credentials
 
 import gspread
-from oauth2client.service_account import ServiceAccountCredentials
+from google.oauth2.service_account import Credentials
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +20,11 @@ class GoogleSheets:
             A dictionary of Google Drive API credentials, parsed from JSON provided
             by the Google Developer Console. Required if env variable
             ``GOOGLE_DRIVE_CREDENTIALS`` is not populated.
+        subject: string
+            In order to use account impersonation, pass in the email address of the account to be impersonated as a string.
     """
 
-    def __init__(self, google_keyfile_dict=None):
+    def __init__(self, google_keyfile_dict=None, subject=None):
 
         scope = [
             'https://spreadsheets.google.com/feeds',
@@ -33,9 +35,10 @@ class GoogleSheets:
         google_credential_file = open(os.environ['GOOGLE_DRIVE_CREDENTIALS'])
         credentials_dict = json.load(google_credential_file)
 
-        credentials = ServiceAccountCredentials.from_json_keyfile_dict(
-            credentials_dict, scope
+        credentials = Credentials.from_service_account_info(
+            credentials_dict, scopes=scope, subject=subject
         )
+
         self.gspread_client = gspread.authorize(credentials)
 
     def _get_worksheet(self, spreadsheet_id, worksheet=0):
@@ -360,7 +363,7 @@ class GoogleSheets:
                         }
                     }, worksheet=0)
 
-        """ # noqa: E501,E261
+        """  # noqa: E501,E261
 
         ws = self._get_worksheet(spreadsheet_id, worksheet)
         ws.format(range, cell_format)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ psycopg2-binary==2.8.5
 xmltodict==0.11.0
 gspread==3.7.0
 oauth2client==4.1.3
+google-auth=2.6.2
 facebook-business==6.0.0
 google-api-python-client==1.7.7
 google-resumable-media!=0.4.0,<0.5.0dev,>=0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psycopg2-binary==2.8.5
 xmltodict==0.11.0
 gspread==3.7.0
 oauth2client==4.1.3
-google-auth=2.6.2
+google-auth==2.6.2
 facebook-business==6.0.0
 google-api-python-client==1.7.7
 google-resumable-media!=0.4.0,<0.5.0dev,>=0.3.1


### PR DESCRIPTION
The oauth2client library is deprecated, and gspread will drop most information from the oauth2client authorization. Switch to the actively maintained google-auth library and add an argument for a delegated account name.

(Merging into moveon branch since that is the base branch we use.)