### PR TITLE
Fix import and linting issues

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -638,7 +638,7 @@ class ActionKit(object):
                 If "desc", return all objects above the threshold value.
             **kwargs:
                 You can also add expressions to filter the data beyond the limit/threshold values
-                above. For addition info, visit `Django's docs on field lookups
+                above. For additional info, visit `Django's docs on field lookups
                 <https://docs.djangoproject.com/en/3.1/topics/db/queries/#field-lookups>`_.
 
                 .. code-block:: python

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -637,9 +637,9 @@ class ActionKit(object):
                 If "asc" (the default), return all objects below the threshold value.
                 If "desc", return all objects above the threshold value.
             **kwargs:
-                You can also add expressions to filter the data beyond the limit/threshold values above. For addition
-                info, visit `Django's docs on field lookups <https://docs.djangoproject.com/\
-                en/3.1/topics/db/queries/#field-lookups>`_.
+                You can also add expressions to filter the data beyond the limit/threshold values
+                above. For addition info, visit `Django's docs on field lookups
+                <https://docs.djangoproject.com/en/3.1/topics/db/queries/#field-lookups>`_.
 
                 .. code-block:: python
 

--- a/parsons/aws/s3.py
+++ b/parsons/aws/s3.py
@@ -2,6 +2,7 @@ import re
 import boto3
 from parsons.utilities import files
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 

--- a/parsons/braintree/braintree.py
+++ b/parsons/braintree/braintree.py
@@ -288,9 +288,9 @@ class Braintree(object):
                 If this is true, include the full collection of transaction objects.
                 Otherwise, just return a list of transaction IDs.
             just_ids: bool
-                While querying a list of subscription ids is a single, fast query to Braintree's API,
-                getting all data for each subscription is force-paginated at 50-records per request.
-                If you just need a count or the list of ids, then set `just_ids=True` and
+                While querying a list of subscription ids is a single, fast query to Braintree's
+                API, getting all data for each subscription is force-paginated at 50-records per
+                request. If you just need a count or the list of ids, then set `just_ids=True` and
                 it will return a single column with `id` instead of all table columns.
             table_of_ids: Table with an `id` column -- i.e. a table returned from `just_ids=True`
                 Subsequently, after calling this with `just_ids`, you can prune/alter the ids table


### PR DESCRIPTION
Add `os` import back to the S3 connector because it's used in line 28, and change a few lines to adhere to flake8 linting.

These are issues that surfaced when creating a [PR](https://github.com/move-coop/parsons/pull/754) in Parsons to get their repo up-to-date with ours.