### PR TITLE
Actionkit orders

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -877,6 +877,30 @@ class ActionKit(object):
                                data=json.dumps(kwargs))
         logger.info(f'{resp.status_code}: {transaction_id}')
 
+    def get_transactions(self, limit=None, **kwargs):
+        """Get multiple transactions.
+
+        `Args:`
+            limit: int
+                The number of transactions to return. If omitted, all transactions are returned.
+            **kwargs:
+                Optional arguments to pass to the client. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
+
+                Additionally, expressions to filter the data can also be provided. For addition
+                info, visit `Django's docs on field lookups <https://docs.djangoproject.com/\
+                en/3.1/topics/db/queries/#field-lookups>`_.
+
+                .. code-block:: python
+
+                    ak.get_transactions(order="order-1")
+        `Returns:`
+            Parsons.Table
+                The events data.
+        """
+        return self.paginated_get('transaction', limit=limit, **kwargs)
+
     def create_generic_action(self, page, email=None, ak_id=None, **kwargs):
         """
         Post a generic action. One of ``ak_id`` or ``email`` is a required argument.

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -715,6 +715,30 @@ class ActionKit(object):
         logger.info(f'{resp.status_code}: {recurring_id}')
         return resp
 
+    def get_orders(self, limit=None, **kwargs):
+        """Get multiple orders.
+
+        `Args:`
+            limit: int
+                The number of orders to return. If omitted, all orders are returned.
+            **kwargs:
+                Optional arguments to pass to the client. A full list can be found
+                in the `ActionKit API Documentation <https://roboticdogs.actionkit.com/docs/\
+                manual/api/rest/actionprocessing.html>`_.
+
+                Additionally, expressions to filter the data can also be provided. For addition
+                info, visit `Django's docs on field lookups <https://docs.djangoproject.com/\
+                en/3.1/topics/db/queries/#field-lookups>`_.
+
+                .. code-block:: python
+
+                    ak.get_orders(import_id="my-import-123")
+        `Returns:`
+            Parsons.Table
+                The events data.
+        """
+        return self.paginated_get('order', limit=limit, **kwargs)
+
     def update_paymenttoken(self, paymenttoken_id, **kwargs):
         """
         Update a saved payment token.

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -681,6 +681,20 @@ class ActionKit(object):
         data = data[:i]
         return Table(data[:limit])
 
+    def get_order(self, order_id):
+        """
+        Get an order.
+
+        `Args:`
+            order_id: int
+                The order id of the record to get.
+        `Returns`:
+            User json object
+        """
+
+        return self._base_get(endpoint='order', entity_id=order_id,
+                              exception_message='Order not found')
+
     def update_order(self, order_id, **kwargs):
         """
         Update an order.

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -402,6 +402,19 @@ class TestActionKit(unittest.TestCase):
             'https://domain.actionkit.com/rest/v1/order/123/', data=json.dumps({'account': 'test'})
         )
 
+    def test_get_orders(self):
+        # Test get orders
+        resp_mock = mock.MagicMock()
+        type(resp_mock.get()).status_code = mock.PropertyMock(return_value=201)
+        type(resp_mock.get()).json = lambda x: {"meta": {"next": ""}, "objects": []}
+        self.actionkit.conn = resp_mock
+
+        self.actionkit.get_orders(100, order_by='created_at')
+        self.actionkit.conn.get.assert_called_with(
+            'https://domain.actionkit.com/rest/v1/order/',
+            params={'order_by': 'created_at', '_limit': 100}
+        )
+
     def test_update_paymenttoken(self):
         # Test update payment token
 

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -526,6 +526,19 @@ class TestActionKit(unittest.TestCase):
             data=json.dumps({'account': 'test'})
         )
 
+    def test_get_transactions(self):
+        # Test get transactions
+        resp_mock = mock.MagicMock()
+        type(resp_mock.get()).status_code = mock.PropertyMock(return_value=201)
+        type(resp_mock.get()).json = lambda x: {"meta": {"next": ""}, "objects": []}
+        self.actionkit.conn = resp_mock
+
+        self.actionkit.get_transactions(100, order_by='created_at')
+        self.actionkit.conn.get.assert_called_with(
+            'https://domain.actionkit.com/rest/v1/transaction/',
+            params={'order_by': 'created_at', '_limit': 100}
+        )
+
     def test_create_generic_action(self):
         # Test create a generic action
 

--- a/test/test_action_kit.py
+++ b/test/test_action_kit.py
@@ -390,6 +390,14 @@ class TestActionKit(unittest.TestCase):
                  ]
         self.actionkit.conn.get.assert_has_calls(calls)
 
+    def test_get_order(self):
+        # Test get order
+        self.actionkit.get_order(123)
+        self.actionkit.conn.get.assert_called_with(
+            'https://domain.actionkit.com/rest/v1/order/123/',
+            params=None
+        )
+
     def test_update_order(self):
         # Test update order
 


### PR DESCRIPTION
Required to [import Shopify Refunds](https://github.com/MoveOnOrg/fundraising_parsons_scripts/pull/142).

I didn't end up needing the `get_order` method, but I thought it would be nice to leave in, in case it is useful to us or others in the future.