### PR TITLE
Fix Salesforce query output

### DIFF
--- a/parsons/salesforce/salesforce.py
+++ b/parsons/salesforce/salesforce.py
@@ -80,8 +80,9 @@ class Salesforce:
             list of dicts with Salesforce data
         """  # noqa: E501,E261
 
-        q = Table(self.client.query_all(soql))
-        logger.info(f"Found {q.num_rows} results")
+        q = self.client.query_all(soql)
+        q=json.loads(json.dumps(q))
+        logger.info(f"Found {q['totalSize']} results")
         return q
 
     def insert_record(self, object, data_table):

--- a/test/test_salesforce/test_salesforce.py
+++ b/test/test_salesforce/test_salesforce.py
@@ -14,7 +14,7 @@ class TestSalesforce(unittest.TestCase):
         self.sf = Salesforce()
         self.sf._client = mock.MagicMock()
 
-        self.sf._client.query_all.return_value = [{"Id": 1, "value": "FAKE"}]
+        self.sf._client.query_all.return_value = {"totalSize": 1, "done": True, "records": [{"attributes": {"type": "Contact", "url": "/services/data/v38.0/sobjects/Contact/1234567890AaBbC"}, "Id": "1234567890AaBbC"}]}
         self.sf._client.bulk.Contact.insert.return_value = [
             {"success": True, "created": True, "id": "1234567890AaBbC", "errors": []}
         ]
@@ -43,7 +43,7 @@ class TestSalesforce(unittest.TestCase):
         fake_soql = "FAKESOQL"
         response = self.sf.query(fake_soql)
         assert self.sf.client.query_all.called_with(fake_soql)
-        self.assertEqual(response[0]["value"], "FAKE")
+        self.assertEqual(response['records'][0]['Id'], '1234567890AaBbC')
 
     def test_insert(self):
 


### PR DESCRIPTION
The existing code did not match the method description and did not produce a useful result.  Salesforce returns a set of nested dicts, similar to JSON; the new method reformats the nested ordered dicts using the json library, similar to describe_fields.