### PR TITLE
Fix ak collect upload errors

### DIFF
--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1307,15 +1307,34 @@ class ActionKit(object):
         for res in result_array:
             upload_id = res.get("id")
             if upload_id:
+                # Pend until upload is complete
                 while True:
                     upload = self._base_get(endpoint="upload", entity_id=upload_id)
-                    if not upload or upload.get("is_completed"):
+                    if upload.get("is_completed"):
                         break
                     else:
                         time.sleep(1)
-                error_data = self._base_get(
-                    endpoint="uploaderror", params={"upload": upload_id}
-                )
-                logger.debug(f"error collect result: {error_data}")
-                errors.extend(error_data.get("objects") or [])
+
+                # ActionKit limits length of error list returned
+                # Iterate until all errors are gathered
+                error_count = upload.get("has_errors")
+                limit = 20
+                offset = 0
+
+                while True:
+                    error_data = self._base_get(
+                        endpoint="uploaderror",
+                        params={
+                            "upload": upload_id,
+                            "_limit": limit,
+                            "_offset": offset,
+                        },
+                    )
+                    logger.debug(f"error collect result: {error_data}")
+                    errors.extend(error_data.get("objects") or [])
+                    offset = offset + limit
+
+                    if error_count <= offset:
+                        break
+
         return errors

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -2,6 +2,7 @@ import json
 import logging
 import requests
 import time
+import math
 
 from parsons.etl.table import Table
 from parsons.utilities import check_env
@@ -1319,22 +1320,18 @@ class ActionKit(object):
                 # Iterate until all errors are gathered
                 error_count = upload.get("has_errors")
                 limit = 20
-                offset = 0
 
-                while True:
+                error_pages = math.ceil(error_count / limit)
+                for page in range(0, error_pages):
                     error_data = self._base_get(
                         endpoint="uploaderror",
                         params={
                             "upload": upload_id,
                             "_limit": limit,
-                            "_offset": offset,
+                            "_offset": page * limit,
                         },
                     )
                     logger.debug(f"error collect result: {error_data}")
                     errors.extend(error_data.get("objects") or [])
-                    offset = offset + limit
-
-                    if error_count <= offset:
-                        break
 
         return errors

--- a/parsons/action_kit/action_kit.py
+++ b/parsons/action_kit/action_kit.py
@@ -1309,7 +1309,7 @@ class ActionKit(object):
             if upload_id:
                 while True:
                     upload = self._base_get(endpoint="upload", entity_id=upload_id)
-                    if not upload or upload.get("status") != "new":
+                    if not upload or upload.get("is_completed"):
                         break
                     else:
                         time.sleep(1)


### PR DESCRIPTION
[Asana task here](https://app.asana.com/0/0/1206314926550180/f).

Steps to test:

- Download the testupload_ak.csv file from the attached Asana task
- Save the file to a new /tmp/ directory in the fundraising_parsons_script directory
- From the fundraising_parsons_scripts dev environment, run the following commands:
```
python
import os
os.environ['PARSONS_SKIP_IMPORT_ALL'] = '1'
from parsons.etl.table import Table  # noqa: E402
from parsons.action_kit import ActionKit  # noqa: E402
from app import credentials
ak = ActionKit(**credentials['action_kit_sandbox'])
ak_table = Table.from_csv('tmp/testupload_ak.csv')
import_page='test-mo-donation-import-page'
args = {'no_overwrite_on_empty': False, 'set_only_columns': [ 'user_do_not_mail', 'user_sms_subscribed', 'home_phone', 'mobile_phone', 'first_name', 'last_name', 'prefix' ]}
res = ak.bulk_upload_table(ak_table, import_page=import_page, **args); errors = ak.collect_upload_errors(res['results']); print(errors)
```

The final commands are on a single line because the delay of a human entering terminal commands is long enough hide the problem.

Before fix: The printed errors object is an empty list: `[]`
After fix: The printed errors object contains exactly 232 errors related to a bad payment account

Run the test once to confirm that the output is `[]` before the fix. Then, run `pip uninstall parsons` and `pip install --no-deps git+https://github.com/moveonorg/parsons.git@fix-ak-collect-upload-errors#egg=parsons`. Run the test again and confirm that the output error list contains exactly 232 errors.

This is a fast solution to my problem, but I think a change to a community repository like parsons deserves more time and attention than I can give today. So, instead of opening a PR into the community repository, I'm opening this draft pull request to facilitate review. My preferred next steps:
- Sophie gives a preliminary review to these changes
- I deploy the Engage sync Lambda with this branch as the parsons dependency
- I continue to clean up and improve these changes
- When ready, I open a PR into the move-coop repository
- Once that is approved and merged, I re-deploy the Engage sync Lamdba with the real parsons dependency

Here are some things I'm still thinking about for this PR (and might be part of the cleanup mentioned above):
- I need to update the tests for this function
- Incrementing offsets doesn't feel very "pythonic". I want to see if there's a better way to iterate through all errors for an upload (such as using the "next" attribute of the `uploaderror` object)
- I want more time to think through why the [original code](https://github.com/move-coop/parsons/commit/2b11fdcd3b23e63717a128f2c5d718264954e8b8) tested `if not upload` to break the while loop. I think `upload` should always be assigned at that point if we haven't encountered an error
- Should we use a higher limit/offset? It looks like ActionKit supports up to 100. Could this be a problem for another organization's ActionKit configuration?